### PR TITLE
add missingDuration properties

### DIFF
--- a/cfn-resource-specification.json
+++ b/cfn-resource-specification.json
@@ -435,6 +435,16 @@
                     "PrimitiveType": "Integer",
                     "Required": false,
                     "UpdateType": "Mutable"
+                },
+                "MissingDurationWarning": {
+                    "PrimitiveType": "Integer",
+                    "Required": false,
+                    "UpdateType": "Mutable"
+                },
+                "MissingDurationCritical": {
+                    "PrimitiveType": "Integer",
+                    "Required": false,
+                    "UpdateType": "Mutable"
                 }
             }
         },


### PR DESCRIPTION
`MissingDurationWarning` and `MissingDurationCritical` are available in macro, but not defined in specification json. I added them.