### PR TITLE
update aws lambda runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ help: ## Show this text.
 
 all: macro.zip resource.zip template.yaml ## Build a package
 
-resource/main: $(SRC_FILES) go.mod go.sum
+resource/bootstrap: $(SRC_FILES) go.mod go.sum
 	mkdir -p resource
-	./run-in-docker.sh go build -o resource/main .
+	./run-in-docker.sh go build -tags lambda.norpc -o resource/bootstrap .
 
 version.go template.yaml: VERSION generate.sh template.template.yaml
 	./generate.sh
@@ -18,7 +18,7 @@ version.go template.yaml: VERSION generate.sh template.template.yaml
 macro.zip: macro/app.py
 	cd macro && zip -r ../macro.zip .
 
-resource.zip: resource/main
+resource.zip: resource/bootstrap
 	cd resource && zip -r ../resource.zip .
 
 test: ## run tests
@@ -30,5 +30,7 @@ test: ## run tests
 	fi
 
 clean:
-	@rm -f resource.zip
-	@rm -f macro.zip
+	-rm -f resource.zip
+	-rm -f macro.zip
+	-rm -rf .build .build-sam resource
+	-docker volume rm cfn-mackerel-macro-cache

--- a/mackerel/mackerel.go
+++ b/mackerel/mackerel.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -161,7 +160,7 @@ func (c *Client) do(ctx context.Context, method, path string, in, out interface{
 
 	if out == nil {
 		// ignore the body
-		io.Copy(ioutil.Discard, resp.Body)
+		io.Copy(io.Discard, resp.Body)
 	} else {
 		dec := json.NewDecoder(resp.Body)
 		if err := dec.Decode(out); err != nil {
@@ -196,7 +195,7 @@ func (e mkrError) Message() string {
 }
 
 func handleError(resp *http.Response) error {
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
 
 CURRENT=$(cd "$(dirname "$0")" && pwd)
+docker volume create cfn-mackerel-macro-cache > /dev/null 2>&1
 docker run --rm -it \
     -e GO111MODULE=on \
     -e GOOS=linux -e GOARCH=amd64 -e CGO_ENABLED=0 \
     -v "$CURRENT/.mod":/go/pkg/mod \
-    -v "$CURRENT":/go/src/github.com/shogo82148/mackerel-cloudwatch-forwarder \
-    -w /go/src/github.com/shogo82148/mackerel-cloudwatch-forwarder golang:1.16.2 "$@"
+    -v "$CURRENT":/go/src/github.com/shogo82148/cfn-mackerel-macro \
+    -w /go/src/github.com/shogo82148/cfn-mackerel-macro golang:1.16.2 "$@"

--- a/template.template.yaml
+++ b/template.template.yaml
@@ -33,7 +33,7 @@ Resources:
   ResourceFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: go1.x
+      Runtime: provided.al2
       CodeUri: ./resource.zip
       Handler: main
       Policies:
@@ -52,7 +52,7 @@ Resources:
   MacroFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python3.7
+      Runtime: python3.8
       CodeUri: ./macro.zip
       Handler: app.handler
       Environment:

--- a/template.yaml
+++ b/template.yaml
@@ -33,13 +33,13 @@ Resources:
   ResourceFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: go1.x
+      Runtime: provided.al2
       CodeUri: ./resource.zip
       Handler: main
       Policies:
         - SSMParameterReadPolicy:
-          # HACK: trim "/" prefix. See https://github.com/aws/serverless-application-model/issues/1112
-          ParameterName: !Join ["", !Split ["^/", !Sub "^${ParameterName}"]]
+            # HACK: trim "/" prefix. See https://github.com/aws/serverless-application-model/issues/1112
+            ParameterName: !Join ["", !Split ["^/", !Sub "^${ParameterName}"]]
       Environment:
         Variables:
           MACKEREL_APIKEY_PARAMETER: !Ref ParameterName
@@ -52,7 +52,7 @@ Resources:
   MacroFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python3.7
+      Runtime: python3.8
       CodeUri: ./macro.zip
       Handler: app.handler
       Environment:


### PR DESCRIPTION
the latest version of the runtimes are:

- `python3.8` for Python
- `provided.al2` for Go

ref. https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html
