### PR TITLE
improve spec test

### DIFF
--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -1,0 +1,22 @@
+name: test spec
+on:
+  push:
+  pull_request:
+    paths:
+      - .github/workflows/test-spec.yml
+      - cfn-resource-specification.json
+      - example.yaml
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: cfn-lint
+        uses: scottbrenner/cfn-lint-action@master
+        with:
+          args: --override-spec cfn-resource-specification.json example.yaml

--- a/.github/workflows/test-spec.yml
+++ b/.github/workflows/test-spec.yml
@@ -16,7 +16,15 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: cfn-lint
-        uses: scottbrenner/cfn-lint-action@master
+      - uses: actions/cache@v2
         with:
-          args: --override-spec cfn-resource-specification.json example.yaml
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip
+
+      - name: install
+        run: |
+          pip install cfn-lint
+
+      - name: cfn-lint
+        run: |
+          cfn-lint --override-spec cfn-resource-specification.json example.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,3 @@ jobs:
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: coverage.out
-
-      - name: cfn-lint
-        uses: scottbrenner/cfn-lint-action@master
-        with:
-          args: --override-spec cfn-resource-specification.json example.yaml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,13 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Test
         run: |
           make test


### PR DESCRIPTION
the test of cfn-lint takes long time.
split workflows and make it faster.