### PR TITLE
fix resource tag property name

### DIFF
--- a/cfn/aws_integration.go
+++ b/cfn/aws_integration.go
@@ -86,7 +86,7 @@ func (r *awsIntegration) convertToParam(ctx context.Context, properties map[stri
 func (r *awsIntegration) convertTagList(d *dproxy.Drain, properties dproxy.Proxy) string {
 	var tags []string
 	for _, tag := range d.ProxyArray(properties.ProxySet()) {
-		name := d.String(tag.M("Name"))
+		name := d.String(tag.M("Key"))
 		value := d.String(tag.M("Value"))
 		tags = append(tags, r.escapeTagValue(name)+":"+r.escapeTagValue(value))
 	}

--- a/cfn/aws_integration_test.go
+++ b/cfn/aws_integration_test.go
@@ -22,7 +22,7 @@ func TestCreateAWSIntegration(t *testing.T) {
 					Region:       "ap-northeast-1",
 					Key:          pointer.String("AKIAIOSFODNN7EXAMPLE"),
 					SecretKey:    pointer.String("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
-					IncludedTags: "TagName:TagValue,\"Tag:Name\":\"Tag,Value\",'Tag\"Name':\"Tag' Value\"",
+					IncludedTags: "TagKey:TagValue,\"Tag:Key\":\"Tag,Value\",'Tag\"Key':\"Tag' Value\"",
 					Services: map[string]*mackerel.AWSIntegrationService{
 						"Billing": {
 							Enable:          false,
@@ -58,15 +58,15 @@ func TestCreateAWSIntegration(t *testing.T) {
 			"SecretKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 			"IncludedTags": []interface{}{
 				map[string]interface{}{
-					"Name":  "TagName",
+					"Key":   "TagKey",
 					"Value": "TagValue",
 				},
 				map[string]interface{}{
-					"Name":  "Tag:Name",
+					"Key":   "Tag:Key",
 					"Value": "Tag,Value",
 				},
 				map[string]interface{}{
-					"Name":  "Tag\"Name",
+					"Key":   "Tag\"Key",
 					"Value": "Tag' Value",
 				},
 			},

--- a/example.yaml
+++ b/example.yaml
@@ -357,6 +357,9 @@ Resources:
       Services:
         - ServiceId: S3
           Enable: true
+      IncludedTags:
+        - Key: Included
+          Value: true
 
   # Example for AWS Integrations using IAM User (deprecated)
   MackerelUser:
@@ -385,6 +388,9 @@ Resources:
       Services:
         - ServiceId: S3
           Enable: true
+      ExcludedTags:
+        - Key: Excluded
+          Value: true
 
 Outputs:
   OrgName:


### PR DESCRIPTION
Hello:wave:
Fixed the name of the resource tag property in the AWS integration.
(Because I get caught in the E3003 error of cfn-lint.)

- AWS official documentation
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html#w2ab1c31c10d388c13c17

- Resource specifications
https://github.com/shogo82148/cfn-mackerel-macro/blob/98ecf8d1d986c71e5f54620658bc593ce554a1ed/cfn-resource-specification.json#L743