### PR TITLE
Support IsMute parameter

### DIFF
--- a/cfn-resource-specification.json
+++ b/cfn-resource-specification.json
@@ -490,6 +490,11 @@
                     "PrimitiveType": "Integer",
                     "Required": false,
                     "UpdateType": "Mutable"
+                },
+                "IsMute": {
+                    "PrimitiveType": "Boolean",
+                    "Required": false,
+                    "UpdateType": "Mutable"
                 }
             }
         },

--- a/cfn/monitor.go
+++ b/cfn/monitor.go
@@ -121,6 +121,7 @@ func (m *monitor) convertToParam(ctx context.Context, properties map[string]inte
 			Scopes:               scopes,
 			ExcludeScopes:        excludeScopes,
 			NotificationInterval: uint64(d.Int64(dproxy.Default(in.M("NotificationInterval"), 0))),
+			IsMute:               d.Bool(dproxy.Default(in.M("IsMute"), false)),
 		}
 	case mackerel.MonitorTypeHostMetric.String():
 		var scopes, excludeScopes []string
@@ -156,6 +157,7 @@ func (m *monitor) convertToParam(ctx context.Context, properties map[string]inte
 			Scopes:               scopes,
 			ExcludeScopes:        excludeScopes,
 			NotificationInterval: uint64(d.Int64(dproxy.Default(in.M("NotificationInterval"), 0))),
+			IsMute:               d.Bool(dproxy.Default(in.M("IsMute"), false)),
 		}
 	case mackerel.MonitorTypeServiceMetric.String():
 		serviceName, err := m.Function.parseServiceID(ctx, d.String(in.M("Service")))
@@ -175,6 +177,7 @@ func (m *monitor) convertToParam(ctx context.Context, properties map[string]inte
 			NotificationInterval:    d.Uint64(dproxy.Default(in.M("NotificationInterval"), 0)),
 			MissingDurationWarning:  d.OptionalUint64(in.M("MissingDurationWarning")),
 			MissingDurationCritical: d.OptionalUint64(in.M("MissingDurationCritical")),
+			IsMute:                  d.Bool(dproxy.Default(in.M("IsMute"), false)),
 		}
 	case mackerel.MonitorTypeExternalHTTP.String():
 		var serviceName string
@@ -215,6 +218,7 @@ func (m *monitor) convertToParam(ctx context.Context, properties map[string]inte
 			CertificationExpirationCritical: d.OptionalUint64(in.M("CertificationExpirationCritical")),
 			SkipCertificateVerification:     d.Bool(dproxy.Default(in.M("SkipCertificateVerification"), false)),
 			Headers:                         headers,
+			IsMute:                          d.Bool(dproxy.Default(in.M("IsMute"), false)),
 		}
 	case mackerel.MonitorTypeExpression.String():
 		mm = &mackerel.MonitorExpression{
@@ -225,6 +229,7 @@ func (m *monitor) convertToParam(ctx context.Context, properties map[string]inte
 			Warning:              d.OptionalFloat64(in.M("Warning")),
 			Critical:             d.OptionalFloat64(in.M("Critical")),
 			NotificationInterval: d.Uint64(dproxy.Default(in.M("NotificationInterval"), 0)),
+			IsMute:               d.Bool(dproxy.Default(in.M("IsMute"), false)),
 		}
 	case mackerel.MonitorTypeAnomalyDetection.String():
 		var scopes []string
@@ -247,6 +252,7 @@ func (m *monitor) convertToParam(ctx context.Context, properties map[string]inte
 			WarningSensitivity:   mackerel.AnomalyDetectionSensitivityType(d.String(dproxy.Default(in.M("WarningSensitivity"), ""))),
 			CriticalSensitivity:  mackerel.AnomalyDetectionSensitivityType(d.String(dproxy.Default(in.M("CriticalSensitivity"), ""))),
 			TrainingPeriodFrom:   mackerel.Timestamp(d.Int64(dproxy.Default(in.M("TrainingPeriodFrom"), 0))),
+			IsMute:               d.Bool(dproxy.Default(in.M("IsMute"), false)),
 		}
 	default:
 		return nil, fmt.Errorf("unknown monitor type: %s", typ)

--- a/cfn/monitor_test.go
+++ b/cfn/monitor_test.go
@@ -23,6 +23,7 @@ func TestCreateMonitor_MonitorConnectivity(t *testing.T) {
 					NotificationInterval: 60,
 					Scopes:               []string{"my-service"},
 					ExcludeScopes:        []string{"my-service:my-role"},
+					IsMute:               true,
 				}
 				if diff := cmp.Diff(param, want); diff != "" {
 					t.Errorf("monitor differs: (-got +want)\n%s", diff)
@@ -46,6 +47,7 @@ func TestCreateMonitor_MonitorConnectivity(t *testing.T) {
 			"Scopes":               []interface{}{"mkr:test-org:service:my-service"},
 			"ExcludeScopes":        []interface{}{"mkr:test-org:role:my-service:my-role"},
 			"NotificationInterval": 60,
+			"IsMute":               true,
 		},
 	}
 	id, param, err := f.Handle(context.Background(), event)
@@ -85,6 +87,7 @@ func TestCreateMonitor_MonitorHostMetric(t *testing.T) {
 					Scopes:               []string{"Hatena-Blog"},
 					ExcludeScopes:        []string{"Hatena-Bookmark:db-master"},
 					NotificationInterval: 60,
+					IsMute:               true,
 				}
 				if diff := cmp.Diff(param, want); diff != "" {
 					t.Errorf("monitor differs: (-got +want)\n%s", diff)
@@ -114,6 +117,7 @@ func TestCreateMonitor_MonitorHostMetric(t *testing.T) {
 			"Scopes":               []interface{}{"mkr:test-org:service:Hatena-Blog"},
 			"ExcludeScopes":        []interface{}{"mkr:test-org:role:Hatena-Bookmark:db-master"},
 			"NotificationInterval": 60,
+			"IsMute":               true,
 		},
 	}
 	id, param, err := f.Handle(context.Background(), event)
@@ -154,6 +158,7 @@ func TestCreateMonitor_MonitorServiceMetric(t *testing.T) {
 					NotificationInterval:    60,
 					MissingDurationWarning:  pointer.Uint64(360),
 					MissingDurationCritical: pointer.Uint64(720),
+					IsMute:                  true,
 				}
 				if diff := cmp.Diff(param, want); diff != "" {
 					t.Errorf("monitor differs: (-got +want)\n%s", diff)
@@ -184,6 +189,7 @@ func TestCreateMonitor_MonitorServiceMetric(t *testing.T) {
 			"MissingDurationWarning":  360,
 			"MissingDurationCritical": 720,
 			"NotificationInterval":    60,
+			"IsMute":                  true,
 		},
 	}
 	id, param, err := f.Handle(context.Background(), event)
@@ -232,6 +238,7 @@ func TestCreateMonitor_MonitorExternalHTTP(t *testing.T) {
 							Value: "no-cache",
 						},
 					},
+					IsMute: true,
 				}
 				if diff := cmp.Diff(param, want); diff != "" {
 					t.Errorf("monitor differs: (-got +want)\n%s", diff)
@@ -269,6 +276,7 @@ func TestCreateMonitor_MonitorExternalHTTP(t *testing.T) {
 					"Value": "no-cache",
 				},
 			},
+			"IsMute": true,
 		},
 	}
 	id, param, err := f.Handle(context.Background(), event)
@@ -305,6 +313,7 @@ func TestCreateMonitor_MonitorExpression(t *testing.T) {
 					Operator:   ">",
 					Warning:    pointer.Float64(5.0),
 					Critical:   pointer.Float64(10.0),
+					IsMute:     true,
 				}
 				if diff := cmp.Diff(param, want); diff != "" {
 					t.Errorf("monitor differs: (-got +want)\n%s", diff)
@@ -330,6 +339,7 @@ func TestCreateMonitor_MonitorExpression(t *testing.T) {
 			"Warning":              5.0,
 			"Critical":             10.0,
 			"NotificationInterval": 60.0,
+			"IsMute":               true,
 		},
 	}
 	id, param, err := f.Handle(context.Background(), event)
@@ -362,6 +372,7 @@ func TestCreateMonitor_MonitorAnomalyDetection(t *testing.T) {
 					Memo:               "my anomaly detection for roles",
 					Scopes:             []string{"myService", "myService:myRole"},
 					WarningSensitivity: mackerel.AnomalyDetectionSensitivityInsensitive,
+					IsMute:             true,
 				}
 				if diff := cmp.Diff(param, want); diff != "" {
 					t.Errorf("monitor differs: (-got +want)\n%s", diff)
@@ -387,6 +398,7 @@ func TestCreateMonitor_MonitorAnomalyDetection(t *testing.T) {
 				"mkr:test-org:role:myService:myRole",
 			},
 			"WarningSensitivity": "insensitive",
+			"IsMute":             true,
 		},
 	}
 	id, param, err := f.Handle(context.Background(), event)

--- a/mackerel/monitor_test.go
+++ b/mackerel/monitor_test.go
@@ -44,6 +44,7 @@ func TestFindMonitors(t *testing.T) {
 				"notificationInterval": 60,
 				"scopes":               []interface{}{"Hatena-Blog"},
 				"excludeScopes":        []interface{}{"Hatena-Bookmark:db-master"},
+				"isMute":               true,
 			},
 			want: &MonitorHostMetric{
 				ID:                   "2cSZzK3XfmG",
@@ -61,6 +62,7 @@ func TestFindMonitors(t *testing.T) {
 
 				Scopes:        []string{"Hatena-Blog"},
 				ExcludeScopes: []string{"Hatena-Bookmark:db-master"},
+				IsMute:        true,
 			},
 		},
 		{
@@ -71,6 +73,7 @@ func TestFindMonitors(t *testing.T) {
 				"memo":          "A monitor that checks connectivity.",
 				"scopes":        []interface{}{"service1"},
 				"excludeScopes": []interface{}{"service1:role3"},
+				"isMute":        true,
 			},
 			want: &MonitorConnectivity{
 				ID:            "2cSZzK3XfmG",
@@ -79,6 +82,7 @@ func TestFindMonitors(t *testing.T) {
 				Type:          MonitorTypeConnectivity,
 				Scopes:        []string{"service1"},
 				ExcludeScopes: []string{"service1:role3"},
+				IsMute:        true,
 			},
 		},
 		{
@@ -97,6 +101,7 @@ func TestFindMonitors(t *testing.T) {
 				"missingDurationWarning":  360,
 				"missingDurationCritical": 720,
 				"notificationInterval":    60,
+				"isMute":                  true,
 			},
 			want: &MonitorServiceMetric{
 				ID:                   "2cSZzK3XfmG",
@@ -115,6 +120,7 @@ func TestFindMonitors(t *testing.T) {
 
 				MissingDurationWarning:  ptrUint64(360),
 				MissingDurationCritical: ptrUint64(720),
+				IsMute:                  true,
 			},
 		},
 		{
@@ -342,6 +348,8 @@ func TestCreateMonitor(t *testing.T) {
 
 				Scopes:        []string{"Hatena-Blog"},
 				ExcludeScopes: []string{"Hatena-Bookmark:db-master"},
+
+				IsMute: true,
 			},
 			want: map[string]interface{}{
 				"type":                 "host",
@@ -356,6 +364,7 @@ func TestCreateMonitor(t *testing.T) {
 				"notificationInterval": 60.0,
 				"scopes":               []interface{}{"Hatena-Blog"},
 				"excludeScopes":        []interface{}{"Hatena-Bookmark:db-master"},
+				"isMute":               true,
 			},
 		},
 		{
@@ -389,6 +398,8 @@ func TestCreateMonitor(t *testing.T) {
 
 				MissingDurationWarning:  ptrUint64(360),
 				MissingDurationCritical: ptrUint64(720),
+
+				IsMute: true,
 			},
 			want: map[string]interface{}{
 				"type":                    "service",
@@ -404,6 +415,7 @@ func TestCreateMonitor(t *testing.T) {
 				"missingDurationWarning":  360.0,
 				"missingDurationCritical": 720.0,
 				"notificationInterval":    60.0,
+				"isMute":                  true,
 			},
 		},
 		{


### PR DESCRIPTION
This pull request adds support for the `IsMute` property to various monitor types in the CloudFormation resource specification and the Go implementation. This allows monitors to be created or updated in a muted state via CloudFormation. The changes also include comprehensive updates to unit tests to ensure the new property is handled correctly.

**Support for `IsMute` property in monitors:**

* Added the `IsMute` property (boolean, mutable) to the CloudFormation resource specification for monitors, enabling mute state management via CloudFormation.
* Updated the `convertToParam` function in `cfn/monitor.go` to handle the `IsMute` property for all relevant monitor types, defaulting to `false` if not provided.

**Unit test enhancements:**

* Updated and expanded test cases in `cfn/monitor_test.go` to cover creation of monitors with the `IsMute` property set, ensuring correct parameter mapping and CloudFormation event handling. 
* Updated monitor creation and retrieval tests in `mackerel/monitor_test.go` to verify correct handling and serialization of the `IsMute` property. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `IsMute` property on monitors, allowing users to mute connectivity, host metric, service metric, external HTTP, expression, and anomaly detection monitors. The property is optional and mutable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->