### PR TITLE
bump Python 3.14

### DIFF
--- a/template.template.yaml
+++ b/template.template.yaml
@@ -1,6 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Transform: AWS::Serverless-2016-10-31
-Description: "cfn-mackerel-macro v__VERSION__ - provide a CloudFormation macro for creating Mackerel resources."
+Description: "cfn-mackerel-macro v__VERSION__ - provide a CloudFormation macro
+  for creating Mackerel resources."
 
 Metadata:
   AWS::ServerlessRepo::Application:
@@ -10,7 +11,7 @@ Metadata:
     SpdxLicenseId: MIT
     LicenseUrl: LICENSE
     ReadmeUrl: README.md
-    Labels: ["macro", "mackerelio"]
+    Labels: [ "macro", "mackerelio" ]
     HomePageUrl: https://github.com/shogo82148/cfn-mackerel-macro
     SemanticVersion: "__VERSION__"
     SourceCodeUrl: https://github.com/shogo82148/cfn-mackerel-macro
@@ -22,7 +23,7 @@ Parameters:
   LogLevel:
     Type: String
     Default: warning
-    AllowedValues: [panic, fatal, error, warn, warning, info, debug, trace]
+    AllowedValues: [ panic, fatal, error, warn, warning, info, debug, trace ]
     Description: log level(panic, fatal, error, warn, warning, info, debug, trace)
   BaseUrl:
     Type: String
@@ -57,8 +58,8 @@ Parameters:
     Default: "resource function for cfn-mackerel-macro"
 
 Conditions:
-  HasMacroFunctionName: !Not [!Equals [!Ref MacroFunctionName, ""]]
-  HasResourceFunctionName: !Not [!Equals [!Ref ResourceFunctionName, ""]]
+  HasMacroFunctionName: !Not [ !Equals [ !Ref MacroFunctionName, "" ] ]
+  HasResourceFunctionName: !Not [ !Equals [ !Ref ResourceFunctionName, "" ] ]
 
 Resources:
   ResourceFunction:
@@ -75,7 +76,7 @@ Resources:
       Policies:
         - SSMParameterReadPolicy:
             # HACK: trim "/" prefix. See https://github.com/aws/serverless-application-model/issues/1112
-            ParameterName: !Join ["", !Split ["^/", !Sub "^${ParameterName}"]]
+            ParameterName: !Join [ "", !Split [ "^/", !Sub "^${ParameterName}" ] ]
       Environment:
         Variables:
           MACKEREL_APIKEY_PARAMETER: !Ref ParameterName
@@ -88,7 +89,7 @@ Resources:
   MacroFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python3.13
+      Runtime: python3.14
       CodeUri: ./macro.zip
       Handler: app.handler
       FunctionName: !If


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Lambda runtime to Python 3.14 for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->